### PR TITLE
Ensure to read service from arguments

### DIFF
--- a/src/http-aws4.js
+++ b/src/http-aws4.js
@@ -71,6 +71,7 @@ if (region == null) {
   region = /([a-z0-9-]+)\.\w+\.amazonaws\.com(?:\/|:|$)/i.exec(url)[1]
 }
 
+service = argv.service
 if (service == null) {
   service = /(\w+)\.amazonaws\.com(?:\/|:|$)/i.exec(url)[1]
 }


### PR DESCRIPTION
Right now this happens:

```javascript
  service = /(\w+)\.amazonaws\.com(?:\/|:|$)/i.exec(url)[1];
                                                        ^

TypeError: Cannot read property '1' of null
    at Object.<anonymous> (/Users/zackehh/.asdf/installs/nodejs/6.9.2/.npm/lib/node_modules/http-aws4/http-aws4.js:72:57)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```

This'll fix it for now.