### PR TITLE
SharedIniFileCredentials now properly calls `refresh()`

### DIFF
--- a/src/http-aws4.js
+++ b/src/http-aws4.js
@@ -237,7 +237,10 @@ const handleResponse = (response) => new Promise((resolve, reject) => {
 })
 
 const getCredentials = (argv.profile != null)
-  ? () => Promise.resolve(new AWS.SharedIniFileCredentials({profile: argv.profile}))
+  ? () => {
+    const creds = new AWS.SharedIniFileCredentials({profile: argv.profile});
+    return pify(creds.refresh).bind(creds)().then(() => creds);
+  }
   : pify(config.getCredentials).bind(config)
 
 const main = () => {


### PR DESCRIPTION
SharedIniFileCredentials now properly calls `refresh()` so that it can fetch session IDs for assumed roles. This makes sense when you realize that under the hood it's actually making an IAM API call to AWS to get the temporary credentials.